### PR TITLE
fix interrupt deactivation in spinlock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "ruspiro-lock"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
-version = "0.2.0" # remember to update html_root_url
+version = "0.2.1" # remember to update html_root_url
 description = """
 Simple atomic locking and safe data access (mutual exclusive) cross cores on Raspberry Pi.
 """
 license = "Apache-2.0"
-repository = "https://github.com/RusPiRo/ruspiro-lock/tree/v0.2.0"
-documentation = "https://docs.rs/ruspiro-lock/0.2.0"
+repository = "https://github.com/RusPiRo/ruspiro-lock/"
+documentation = "https://docs.rs/ruspiro-lock/0.2.1"
 readme = "README.md"
 keywords = ["RusPiRo", "spinlock", "semaphore", "datalock", "raspberrypi"]
 categories = ["no-std", "embedded"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
  * Author: André Borrmann 
  * License: Apache License 2.0
  **********************************************************************************************************************/
-#![doc(html_root_url = "https://docs.rs/ruspiro-lock/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/ruspiro-lock/0.2.1")]
 #![no_std]
 #![feature(asm)]
 

--- a/src/spinlock.rs
+++ b/src/spinlock.rs
@@ -22,7 +22,7 @@
 //!     LOCK.release(); // releasing the lock
 //! }
 //! ```
-use core::sync::atomic::{AtomicBool, Ordering, fence};
+use core::sync::atomic::{AtomicBool, Ordering};
 
 #[derive(Debug)]
 pub struct Spinlock {

--- a/src/spinlock.rs
+++ b/src/spinlock.rs
@@ -42,22 +42,17 @@ impl Spinlock {
     }
 
     pub fn aquire(&self) {
-        // set the atomic value to true if it has been false before
-        // it returns "false" (the old value) if the value could be changed to true
-        // we need to deactivate interrupts as this wait should never beeing interrupted
+        // set the atomic value to true if it has been false before (set the lock)
+        // we need to deactivate interrupts as this wait and the aquired lock should never beeing interrupted
         // otherwise it could lead to deadlocks
         crate::disable_interrupts();
-        while self.flag.compare_and_swap(false, true, Ordering::Relaxed) != false { }
-        // the fence ensures propper ordering with the unlock call
-        fence(Ordering::Acquire);
-        crate::re_enable_interrupts();
+        while self.flag.compare_and_swap(false, true, Ordering::SeqCst) != false { }
     }
 
     pub fn release(&self) {
-        // we need to deactivate interrupts as this atomic operation should never beeing interrupted
-        // otherwise it could lead to deadlocks
-        crate::disable_interrupts();
-        self.flag.store(false, Ordering::Release);
+        self.flag.store(false, Ordering::SeqCst);
+        // re-activate interrupts to the previous enable-state as the lock is now released
+        // and no interrupt deadlocks can occur
         crate::re_enable_interrupts();
     }
 }


### PR DESCRIPTION
Ensure interrupts are disable during the whole time the spinlock is acquired to prevent deadlock situations.