### PR TITLE
improve async test stability

### DIFF
--- a/src/async/asyncrwlock.rs
+++ b/src/async/asyncrwlock.rs
@@ -299,7 +299,7 @@ mod tests {
             // if this async is started first wait a bit to really run the
             // other one first to aquire the AsyncMutexLock
             task::yield_now().await;
-            task::sleep(Duration::from_millis(100)).await;
+            task::sleep(Duration::from_secs(1)).await;
             let guard = rwlock.lock().await;
             let value = **guard;
             assert_eq!(20, value);
@@ -327,7 +327,7 @@ mod tests {
             // if this async is started first wait a bit to really run the
             // other one first to aquire the AsyncMutexLock
             task::yield_now().await;
-            task::sleep(Duration::from_millis(100)).await;
+            task::sleep(Duration::from_secs(1)).await;
             let guard = rwlock.read().await;
             let value = **guard;
             assert_eq!(20, value);
@@ -356,7 +356,7 @@ mod tests {
             // if this async is started first wait a bit to really run the
             // other one first to aquire the AsyncWriteLock
             task::yield_now().await;
-            task::sleep(Duration::from_millis(100)).await;
+            task::sleep(Duration::from_secs(1)).await;
             let mut guard = rwlock.lock().await;
             **guard = 20;
         });

--- a/src/async/asyncrwlock.rs
+++ b/src/async/asyncrwlock.rs
@@ -347,16 +347,14 @@ mod tests {
             let guard = rwlock_clone.read().await;
             // with the AsyncReadLock in place wait a second to keep the guard
             // alive and let the second task relly wait for this one
-            task::yield_now().await;
-            task::sleep(Duration::from_secs(1)).await;
+            task::sleep(Duration::from_secs(10)).await;
             println!("{}", **guard);
         });
 
         let task2 = task::spawn(async move {
             // if this async is started first wait a bit to really run the
             // other one first to aquire the AsyncWriteLock
-            task::yield_now().await;
-            task::sleep(Duration::from_secs(1)).await;
+            task::sleep(Duration::from_secs(5)).await;
             let mut guard = rwlock.lock().await;
             **guard = 20;
         });


### PR DESCRIPTION
Improve the async RWLock unittest stability as the currently used threads seem to easy run into a deadlock situation.