### PR TITLE
Enable the data sealed in the locks to be retrieved back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## :peach: v0.4.1
+
+- ### :bulb: Features
+
+  - provide method `into_inner` for the `Mutex`, `RWLock` and their async variation to be able move the contained the sealed data out of the locks.
+
 ## :peach: v0.4.0
 
 This version provides a major refactoring to introduce commonly used names for the different kinds of locks. `Datalock` becomes `Mutex` and `DataRWlock` becomes `RWLock`. With a feature gate also `async` versions of those locks are introduced.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,11 +23,11 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e88fddcf665081df6cd9d36f1d07f4f8988ca8783bdc3717ff126dca984602"
+checksum = "eb877970c7b440ead138f6321a3b5395d6061183af779340b65e20c0fede9146"
 dependencies = [
- "async-task 4.0.0",
+ "async-task",
  "concurrent-queue",
  "fastrand",
  "futures-lite",
@@ -37,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "1.1.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5735bb89043cba09ab3a2c30cd7cba18fc06a179257e9353a91afcae00bba484"
+checksum = "73079b49cd26b8fd5a15f68fc7707fc78698dc2a3d61430f2a7a9430230dfa04"
 dependencies = [
  "async-executor",
  "async-io",
@@ -77,15 +77,14 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.6.4"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c92085acfce8b32e5b261d0b59b8f3309aee69fea421ea3f271f8b93225754f"
+checksum = "a7e82538bc65a25dbdff70e4c5439d52f068048ab97cdea0acd73f131594caa1"
 dependencies = [
  "async-attributes",
  "async-global-executor",
  "async-io",
  "async-mutex",
- "async-task 3.0.0",
  "blocking",
  "crossbeam-utils",
  "futures-channel",
@@ -103,12 +102,6 @@ dependencies = [
  "slab",
  "wasm-bindgen-futures",
 ]
-
-[[package]]
-name = "async-task"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17772156ef2829aadc587461c7753af20b7e8db1529bc66855add962a3b35d3"
 
 [[package]]
 name = "async-task"
@@ -167,6 +160,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "concurrent-queue"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,13 +175,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
+name = "const_fn"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
+ "const_fn",
  "lazy_static",
 ]
 
@@ -221,9 +227,9 @@ checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
 
 [[package]]
 name = "futures-lite"
-version = "1.7.0"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b77e08e656f472d8ea84c472fa8b0a7a917883048e1cf2d4e34a323cd0aaf63"
+checksum = "5e6c079abfac3ab269e2927ec048dabc89d009ebfdda6b8ee86624f30c689658"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -292,7 +298,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -351,7 +357,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0307b8c7f438902536321f63c28cab0362f6ee89f1c7da47e3642ff956641c8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "log",
  "wepoll-sys-stjepang",
@@ -378,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "ruspiro-lock"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-std",
 ]
@@ -424,7 +430,7 @@ version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "wasm-bindgen-macro",
 ]
 
@@ -449,7 +455,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "js-sys",
  "wasm-bindgen",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruspiro-lock"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
-version = "0.4.0" # remember to update html_root_url
+version = "0.4.1" # remember to update html_root_url
 description = """
 Providing Spinlock, Semaphore and mutual exclusive data access for cross core
 usage on Raspberry Pi.
@@ -24,7 +24,7 @@ is-it-maintained-open-issues = { repository = "RusPiRo/ruspiro-lock" }
 
 [dev-dependencies]
 # to run async unit test cases
-async-std = { version = "1.6.4", features = ["attributes", "unstable"] }
+async-std = { version = "1.7.0", features = ["attributes", "unstable"] }
 
 [dependencies]
 

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -123,6 +123,14 @@ impl<T> Mutex<T> {
             }
         }
     }
+
+    /// Consume the Mutex and return the inner value
+    pub fn into_inner(self) -> T
+    where
+        T: Sized,
+    {
+        self.data.into_inner()
+    }
 }
 
 impl<T> core::fmt::Debug for Mutex<T>

--- a/src/sync/rwlock.rs
+++ b/src/sync/rwlock.rs
@@ -101,11 +101,11 @@ impl<T> RWLock<T> {
     pub fn try_read(&self) -> Option<ReadLockGuard<T>> {
         // read locks can only handed out if no write lock is existing already
         if self.write_lock.load(Ordering::Relaxed) {
-            return None;
+            None
         } else {
             self.read_locks.fetch_add(1, Ordering::Acquire);
             //println!("read lock aquired {:?}", core::any::type_name::<T>());
-            return Some(ReadLockGuard { _data: self });
+            Some(ReadLockGuard { _data: self })
         }
     }
 
@@ -136,6 +136,14 @@ impl<T> RWLock<T> {
     /// accessor of the RWLock until the returned borrow goes out of scope.
     pub unsafe fn as_ref_unchecked(&self) -> &T {
         &*self.data.get()
+    }
+
+    /// Consume the Mutex and return the inner value
+    pub fn into_inner(self) -> T
+    where
+        T: Sized,
+    {
+        self.data.into_inner()
     }
 }
 
@@ -217,7 +225,7 @@ impl<T> Deref for ReadLockGuard<'_, T> {
 /// The RWLock is always `Sync`, to make it `Send` as well it need to be wrapped into an `Arc`.
 unsafe impl<T> Sync for RWLock<T> {}
 
-#[cfg(test)]
+#[cfg(testing)]
 mod tests {
     extern crate alloc;
     use super::*;


### PR DESCRIPTION
This PR provides `into_inner` methods for the locks to allow the sealed data to be retrieved back if required.