### PR TITLE
toolchain update, function renaming, ediiton 2021

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-09-05
+          toolchain: nightly-2021-12-24
           override: true
           components: rust-src, llvm-tools-preview
           target: aarch64-unknown-none
@@ -44,7 +44,7 @@ jobs:
           cat Cargo.toml
 
       - name: Compile
-        run: cargo make pi3 --profile pipeline
+        run: cargo make build --profile pipeline
 
   publish_dry:
     name: Run Cargo Publish Dry-Run
@@ -62,7 +62,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-09-05
+          toolchain: nightly-2021-12-24
           override: true
           components: rust-src, llvm-tools-preview
           target: aarch64-unknown-none
@@ -152,7 +152,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-09-05
+          toolchain: nightly-2021-12-24
           override: true
           components: rust-src, llvm-tools-preview
           target: aarch64-unknown-none

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## :melon: v0.5.0
+
+- ### :wrench: Maintenance
+
+  - Enable the crate to build with the latest nightly version and also fix this in the `rust-toolchain.toml` file.
+  - use Rust edition 2021
+  - Rename the RWLock functions that provides a write lock from `lock` to `write`. This corresponds to read lock provided by the `read` functions.
+
 ## :peach: v0.4.3
 
 - ### :wrench: Maintenance

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "ruspiro-lock"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "async-std",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruspiro-lock"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
-version = "0.4.3" # remember to update html_root_url
+version = "0.5.0" # remember to update html_root_url
 description = """
 Providing Spinlock, Semaphore and mutual exclusive data access for cross core
 usage on Raspberry Pi.
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/ruspiro-lock/||VERSION||"
 readme = "README.md"
 keywords = ["RusPiRo", "spinlock", "semaphore", "mutex", "rwlock"]
 categories = ["no-std", "embedded"]
-edition = "2018"
+edition = "2021"
 exclude = ["Makefile.toml", ".cargo/config.toml"]
 
 [badges]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -17,12 +17,9 @@ CFLAGS = "-march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune
 RUSTFLAGS = "-C linker=${CC} -C target-cpu=cortex-a53"
 
 [tasks.build]
+env = { FEATURES = "async_locks" }
 command = "cargo"
 args = ["build", "--release", "--features", "${FEATURES}"]
-
-[tasks.pi3]
-env = { FEATURES = "async_locks" }
-run_task = "build"
 
 [tasks.clippy]
 env = { FEATURES = "async_locks" }

--- a/README.md
+++ b/README.md
@@ -96,8 +96,9 @@ fn main() {
     {
         // multiple read locks are possible
         let data = rwlock.read();
-        // if a write lock exists no other write or  read lock's could be aquired
+        // if a read lock exists other read lock's can be aquired, but no write lock
         assert!(rwlock_clone.try_read().is_some());
+        assert!(rwlock_clone.try_lock().is_none());
         println!("{}", *data);
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2021-09-05"
+channel = "nightly-2021-12-24"
 components = [ "rustfmt", "clippy", "rust-src", "llvm-tools-preview" ]
 profile = "minimal"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
  **********************************************************************************************************************/
 #![doc(html_root_url = "https://docs.rs/ruspiro-lock/||VERSION||")]
 #![cfg_attr(not(any(test, doctest)), no_std)]
-#![feature(asm)]
 
 //! # Atomic locks for Raspberry Pi baremetal systems
 //!

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -35,6 +35,7 @@
 //! of the ``Arc``.
 //!
 
+use core::arch::asm;
 use core::cell::UnsafeCell;
 use core::fmt;
 use core::ops::{Deref, DerefMut};

--- a/src/sync/semaphore.rs
+++ b/src/sync/semaphore.rs
@@ -24,6 +24,7 @@
 //!     SEMA.up(); // increase the counter for another usage
 //! }
 //! ```
+use core::arch::asm;
 use core::sync::atomic::{AtomicU32, Ordering};
 
 /// Simple counting blocking or non-blocking lock

--- a/src/sync/spinlock.rs
+++ b/src/sync/spinlock.rs
@@ -24,6 +24,7 @@
 //!     LOCK.release(); // releasing the lock
 //! }
 //! ```
+use core::arch::asm;
 use core::sync::atomic::{AtomicBool, Ordering};
 
 /// A blocking cross core lock to guarantee mutual exclusive access. While this lock might block other cores


### PR DESCRIPTION
- Update to build with latest nightly
- use Rust edition 2021 in cargo.toml
- Rename `lock` functions in RWLock to `write` to be consistent with existing `read` functions.